### PR TITLE
Add visibility flag to hide the plugin from napari hub

### DIFF
--- a/.napari/config.yml
+++ b/.napari/config.yml
@@ -1,0 +1,1 @@
+visibility: hidden


### PR DESCRIPTION
This change allow the plugin to be hide on napari hub home page, but still available to access plugin page with correct URL