### PR TITLE
Use extent.world_extent rather than dims.range when drawing slice lines

### DIFF
--- a/ortho_view_napari/_dock_widget.py
+++ b/ortho_view_napari/_dock_widget.py
@@ -128,27 +128,30 @@ class Widget(QWidget):
     def get_x_line(self) -> List[List[int]]:
         z_dims = self.z_viewer.dims
         y_dims = self.y_viewer.dims
+        world_extent = self.z_viewer.layers.extent.world
         line = [
-            [z_dims.current_step[-3], y_dims.current_step[-2], z_dims.range[-1][0]],
-            [z_dims.current_step[-3], y_dims.current_step[-2], z_dims.range[-1][1]],
+            [z_dims.current_step[-3], y_dims.current_step[-2], world_extent[0][-1]],
+            [z_dims.current_step[-3], y_dims.current_step[-2], world_extent[1][-1]],
         ]
         return line
 
     def get_y_line(self) -> List[List[int]]:
         z_dims = self.z_viewer.dims
         x_dims = self.x_viewer.dims
+        world_extent = self.z_viewer.layers.extent.world
         line = [
-            [z_dims.current_step[-3], z_dims.range[-2][0], x_dims.current_step[-1]],
-            [z_dims.current_step[-3], z_dims.range[-2][1], x_dims.current_step[-1]],
+            [z_dims.current_step[-3], world_extent[0][-2], x_dims.current_step[-1]],
+            [z_dims.current_step[-3], world_extent[1][-2], x_dims.current_step[-1]],
         ]
         return line
 
     def get_z_line(self) -> List[List[int]]:
         y_dims = self.y_viewer.dims
         x_dims = self.x_viewer.dims
+        world_extent = self.y_viewer.layers.extent.world
         line = [
-            [y_dims.range[-3][0], y_dims.current_step[-2], x_dims.current_step[-1]],
-            [y_dims.range[-3][1], y_dims.current_step[-2], x_dims.current_step[-1]],
+            [world_extent[0][-3], y_dims.current_step[-2], x_dims.current_step[-1]],
+            [world_extent[1][-3], y_dims.current_step[-2], x_dims.current_step[-1]],
         ]
         return line
 


### PR DESCRIPTION
Hi @JoOkuma, this is a small fix for compatibility with some recent changes made in napari/napari#3381. Specifically the range of the Dims object is now "exclusive" rather than "inclusive" (i.e. an image of extent 512 now has range (0, 512)  like a python slice object would). This change to the upper limit causes problems with this plugin where the slice overlay lines actually end up progressively growing as you drag the sliders.

Fortunately, using `viewer.layers.extent.world_extent` rather than the `range` values resolves the issue satisfactorily both before and after the changes in napari/napari#3381. After that PR, the world extent covers exactly to the edges of the image pixels whereas for v0.4.11 the world extent is shorter by 0.5 pixel on each end. In practice being shorter by 0.5 pixel is not very noticeable unless zoomed in closely near the image edge.

I tried this out for both v0.4.11 and the current napari development branch on 3D data with anisotropic shape to verify all slider lengths looked correct.
