### PR TITLE
Add `npe2` manifest and `visibility` flag

### DIFF
--- a/ortho_view_napari/__init__.py
+++ b/ortho_view_napari/__init__.py
@@ -7,5 +7,4 @@ except ImportError:
 
 
 
-from ._dock_widget import napari_experimental_provide_dock_widget
-
+from ._dock_widget import Widget

--- a/ortho_view_napari/_dock_widget.py
+++ b/ortho_view_napari/_dock_widget.py
@@ -1,7 +1,6 @@
 
 import napari
 from napari.layers.utils._link_layers import link_layers, unlink_layers
-from napari_plugin_engine import napari_hook_implementation
 from qtpy.QtWidgets import QWidget, QVBoxLayout
 from magicgui.widgets import Checkbox
 from typing import List, Optional
@@ -154,9 +153,3 @@ class Widget(QWidget):
             [world_extent[1][-3], y_dims.current_step[-2], x_dims.current_step[-1]],
         ]
         return line
-
-
-@napari_hook_implementation
-def napari_experimental_provide_dock_widget():
-    # you can return either a single widget, or a sequence of widgets
-    return Widget, dict(name='Ortho View')

--- a/ortho_view_napari/napari.yaml
+++ b/ortho_view_napari/napari.yaml
@@ -1,0 +1,11 @@
+name: ortho-view-napari
+visibility: hidden
+schema_version: 0.2.0
+contributions:
+  commands:
+  - id: ortho-view-napari.Widget
+    title: Create Ortho View
+    python_name: ortho_view_napari:Widget
+  widgets:
+  - command: ortho-view-napari.Widget
+    display_name: Ortho View

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = ortho-view-napari
-
 author = Jordao Bragantini
 author_email = jordao.bragantini@czbiohub.org
 license = BSD-3
@@ -8,33 +7,38 @@ url = https://github.com/JoOkuma/ortho-view-napari
 description = It displays the lateral view of the current 3D stack. This could be a starting point for a orthorviewer.
 long_description = file: README.md
 long_description_content_type = text/markdown
-classifiers =
-    Development Status :: 2 - Pre-Alpha
-    Intended Audience :: Developers
-    Framework :: napari
-    Topic :: Software Development :: Testing
-    Programming Language :: Python
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Operating System :: OS Independent
-    License :: OSI Approved :: BSD License
-project_urls =
-    Bug Tracker = https://github.com/JoOkuma/ortho-view-napari/issues
-    Documentation = https://github.com/JoOkuma/ortho-view-napari#README.md
-    Source Code = https://github.com/JoOkuma/ortho-view-napari
-    User Support = https://github.com/JoOkuma/ortho-view-napari/issues
+classifiers = 
+	Development Status :: 2 - Pre-Alpha
+	Intended Audience :: Developers
+	Framework :: napari
+	Topic :: Software Development :: Testing
+	Programming Language :: Python
+	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3.7
+	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: 3.9
+	Operating System :: OS Independent
+	License :: OSI Approved :: BSD License
+project_urls = 
+	Bug Tracker = https://github.com/JoOkuma/ortho-view-napari/issues
+	Documentation = https://github.com/JoOkuma/ortho-view-napari#README.md
+	Source Code = https://github.com/JoOkuma/ortho-view-napari
+	User Support = https://github.com/JoOkuma/ortho-view-napari/issues
 
 [options]
 packages = find:
 python_requires = >=3.7
 setup_requires = setuptools_scm
 # add your package requirements here
-install_requires =
-    napari-plugin-engine>=0.1.4
-    numpy
+install_requires = 
+	napari-plugin-engine>=0.1.4
+	numpy
+include_package_data = True
 
 [options.entry_points]
-napari.plugin = 
-    ortho-view-napari = ortho_view_napari
+napari.manifest = 
+	ortho-view-napari = ortho_view_napari:napari.yaml
+
+[options.package_data]
+ortho_view_napari = napari.yaml
+

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,4 @@ from setuptools import setup
 use_scm = {"write_to": "ortho_view_napari/_version.py"}
 setup(
       use_scm_version=use_scm,
-      entry_points={'napari.plugin': 'OtherView = ortho_view_napari'},
 )


### PR DESCRIPTION
Hello, I've opened this PR because you have `visibility: hidden` set in your napari hub config file. The napari core devs and napari hub team are in the process of updating the napari hub to use the visibility flag in the plugin manifest, so I've converted your plugin to `npe2` and added this flag there as well.

The napari hub changes aren't released yet, but this will be a hard deprecation of the flag in its current location, so I've not yet removed it from `.napari-hub/config.yml`. Once changes to the napari hub are all released I'll make a follow up PR to remove the unused flag. 

Note that once we proceed with the deprecation, if you make a new release without this PR, your plugin will become visible on the napari hub.

Please let me know if you have any questions about this PR or if anything is unclear :blush: